### PR TITLE
feat: release v3 with OpenID Connect support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,17 @@
+# 3.0.0
+
+## Breaking changes
+
+- Use LinkedIn's current OpenID Connect scopes, `openid profile email`, by default
+- Warn when a custom scope omits `openid` without blocking the authorization flow; applications that still depend on the deprecated `r_emailaddress` or `r_liteprofile` flow should remain on version 2
+- Normalize space-delimited, `%20`-encoded, comma-delimited, and `+`-delimited scope values before creating the authorization URL
+- Remove the runtime legacy-flow deprecation warning introduced in version 2.1
+
+## Documentation
+
+- Add a version 2 to version 3 migration guide
+- Document the OpenID Connect ID token and UserInfo response alongside the existing server-side authorization-code exchange guidance
+
 # 2.1.0
 
 ## Features

--- a/MIGRATION-from-2-to-3.md
+++ b/MIGRATION-from-2-to-3.md
@@ -1,0 +1,53 @@
+# Migrating from version 2 to version 3
+
+Version 3 targets **Sign in with LinkedIn using OpenID Connect**. LinkedIn deprecated the legacy Sign In with LinkedIn product and its `r_liteprofile` and `r_emailaddress` scopes on August 1, 2023.
+
+## 1. Enable the OpenID Connect product
+
+In the LinkedIn Developer Portal, open your application and request the **Sign in with LinkedIn using OpenID Connect** product from the Products tab. Confirm that the callback URL used by your application is registered as an authorized redirect URL.
+
+## 2. Upgrade the package
+
+```shell
+pnpm add react-linkedin-login-oauth2@^3
+```
+
+Version 3 changes the default scope from `r_emailaddress` to `openid profile email`. If you omit `scope`, no source-code change is needed:
+
+```js
+const { linkedInLogin } = useLinkedIn({
+  clientId,
+  redirectUri,
+  onSuccess,
+  onError,
+});
+```
+
+If you provide `scope`, replace the legacy scopes and make sure `openid` is included:
+
+```diff
+- scope: 'r_liteprofile r_emailaddress'
++ scope: 'openid profile email'
+```
+
+The `profile` and `email` scopes may be omitted when your application does not need those claims. Version 3 warns when `openid` is missing because LinkedIn requires it for OpenID Connect, but the library does not block the authorization flow.
+
+## 3. Handle the token response on your backend
+
+The browser API is unchanged: `onSuccess` receives an authorization code. Send it to your backend and exchange it at LinkedIn's token endpoint. With the OpenID Connect scopes, the successful token response includes an ID token in addition to the access token.
+
+Validate the ID token on your backend using LinkedIn's OpenID Connect discovery metadata and signing keys. At minimum, validate its signature, issuer, audience, and expiration. Do not treat an unverified, decoded JWT payload as an authenticated identity.
+
+You can use the verified ID token claims or call `https://api.linkedin.com/v2/userinfo` with the access token. The `email` and `email_verified` claims are optional, so handle their absence.
+
+Never put the LinkedIn Client Secret or token-exchange logic in browser code.
+
+## Staying on the legacy flow
+
+Existing applications that cannot migrate from `r_liteprofile` or `r_emailaddress` yet should remain on the latest version 2 release:
+
+```shell
+pnpm add react-linkedin-login-oauth2@^2
+```
+
+LinkedIn no longer supports the legacy product for new applications.

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# React Linked In Login Using OAuth 2.0
+# React LinkedIn Login Using OAuth 2.0 and OpenID Connect
 
 <!-- ALL-CONTRIBUTORS-BADGE:START - Do not remove or modify this section -->
 
@@ -15,20 +15,20 @@
 
 Demo: https://stupefied-goldberg-b44ee5.netlify.app/
 
-> [!WARNING]
-> LinkedIn deprecated the legacy **Sign In with LinkedIn** product on August 1, 2023. Version 2 of this library is maintained for existing applications that still use the legacy `r_emailaddress` and `r_liteprofile` scopes. If you are creating a new application, use version 3 of this library with [Sign In with LinkedIn using OpenID Connect](https://learn.microsoft.com/en-us/linkedin/consumer/integrations/self-serve/sign-in-with-linkedin-v2).
+Version 3 uses LinkedIn's current [Sign in with LinkedIn using OpenID Connect](https://learn.microsoft.com/en-us/linkedin/consumer/integrations/self-serve/sign-in-with-linkedin-v2) product. OpenID Connect (OIDC) is an identity layer built on top of OAuth 2.0: OAuth 2.0 provides the authorization-code flow, while OIDC adds the ID token used to authenticate the member. Migrating from version 2? Follow the [version 2 to version 3 migration guide](./MIGRATION-from-2-to-3.md).
 
-This library completes the browser portion of LinkedIn's OAuth 2.0 authorization flow and returns an **authorization code**. It does not exchange that code for an access token. Your application must send the code to its backend, where the backend exchanges it with LinkedIn using the application's client secret. See [Exchange the authorization code](#exchange-the-authorization-code).
+This library completes the browser portion of LinkedIn's OpenID Connect authorization-code flow and returns an **authorization code**. It does not exchange that code for tokens. Your application must send the code to its backend, where the backend exchanges it with LinkedIn using the application's client secret. See [Exchange the authorization code](#exchange-the-authorization-code).
 
 ## Table of contents
 
-- [React Linked In Login Using OAuth 2.0](#react-linked-in-login-using-oauth-20)
+- [React LinkedIn Login Using OAuth 2.0 and OpenID Connect](#react-linkedin-login-using-oauth-20-and-openid-connect)
   - [Table of contents](#table-of-contents)
   - [Changelog](#changelog)
   - [Installation](#installation)
   - [Overview](#overview)
   - [Usage](#usage)
   - [Exchange the authorization code](#exchange-the-authorization-code)
+  - [Use the OpenID Connect identity](#use-the-openid-connect-identity)
   - [Security](#security)
 - [Support IE](#support-ie)
   - [Demo](#demo)
@@ -45,23 +45,19 @@ See [CHANGELOG.md](https://github.com/nvh95/react-linkedin-login-oauth2/blob/mas
 
 ## Installation
 
-For a new application, install version 3 or above and use LinkedIn's OpenID Connect flow:
+Install version 3:
 
 ```shell
-pnpm add react-linkedin-login-oauth2@^3
+pnpm add react-linkedin-login-oauth2
 ```
 
-Only existing applications that depend on the deprecated legacy scopes should install version 2:
-
-```shell
-pnpm add react-linkedin-login-oauth2@^2
-```
+In the LinkedIn Developer Portal, add the **Sign in with LinkedIn using OpenID Connect** product to your application and register the exact callback URL that you pass as `redirectUri`.
 
 ## Overview
 
 Call `linkedInLogin` using `useLinkedIn` (recommended) or the `LinkedIn` render-props component. A popup asks the member to authorize your application. LinkedIn then redirects the popup to your `redirectUri`, where `LinkedInCallback` sends the authorization code back to the original window. Your `onSuccess` callback receives that code.
 
-The authorization code is not an access token and cannot be used directly to call LinkedIn APIs. Send it to your backend immediately and exchange it as described below.
+The authorization code is not an access token or ID token and cannot be used directly to authenticate a user or call LinkedIn APIs. Send it to your backend immediately and exchange it as described below.
 
 ## Usage
 
@@ -89,6 +85,7 @@ function LinkedInPage() {
     },
     popupWidth: 700,
     popupHeight: 700,
+    // Defaults to 'openid profile email'. The library warns if a custom scope omits 'openid'.
   });
 
   return (
@@ -175,8 +172,9 @@ The `code` passed to `onSuccess` is short-lived. Your application should complet
 1. Send the code from the browser to an endpoint on your own backend over HTTPS.
 2. From the backend, send a form-encoded `POST` request to `https://www.linkedin.com/oauth/v2/accessToken`.
 3. Include `grant_type`, `code`, `client_id`, `client_secret`, and the same `redirect_uri` used for authorization.
-4. Check LinkedIn's response and securely store or use the returned access token on the backend.
-5. Create your application's own login session, preferably using a secure, HTTP-only cookie.
+4. Validate the returned ID token before using its claims as an authenticated identity.
+5. Securely store or use the returned access token on the backend.
+6. Create your application's own login session, preferably using a secure, HTTP-only cookie.
 
 The token exchange must run on a server. For example:
 
@@ -212,6 +210,28 @@ Your `/api/auth/linkedin/exchange` handler should call this function with the au
 
 See LinkedIn's official [Authorization Code Flow](https://learn.microsoft.com/en-us/linkedin/shared/authentication/authorization-code-flow) documentation for the request fields, response format, token lifetime, and refresh behavior.
 
+## Use the OpenID Connect identity
+
+When `openid` is requested, LinkedIn's successful token response includes an `id_token` JWT. Validate it on your backend using LinkedIn's [OpenID Connect discovery metadata](https://www.linkedin.com/oauth/.well-known/openid-configuration) and JSON Web Key Set. Validate at least the token signature, `iss`, `aud`, and `exp` claims before trusting the identity. Decoding a JWT without verifying it is not authentication.
+
+The verified ID token can contain `sub`, `name`, `given_name`, `family_name`, `picture`, `email`, and `email_verified`. The email claims are optional and may be absent.
+
+You can also retrieve the member details from LinkedIn's UserInfo endpoint on your backend:
+
+```js
+const response = await fetch('https://api.linkedin.com/v2/userinfo', {
+  headers: { Authorization: `Bearer ${accessToken}` },
+});
+
+if (!response.ok) {
+  throw new Error(`LinkedIn UserInfo request failed: ${response.status}`);
+}
+
+const profile = await response.json();
+```
+
+See LinkedIn's [OpenID Connect documentation](https://learn.microsoft.com/en-us/linkedin/consumer/integrations/self-serve/sign-in-with-linkedin-v2) for the current claims and endpoints.
+
 ## Security
 
 > [!CAUTION]
@@ -232,19 +252,19 @@ The LinkedIn Client ID is public and may be passed to this library. The Client S
 
 - `LinkedIn` component:
 
-| Parameter         | value    | is required |                                                                                             default                                                                                              |
-| ----------------- | -------- | :---------: | :----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------: |
-| clientId          | string   |     yes     |                                                                                                                                                                                                  |
-| redirectUri       | string   |     yes     |                                                                                                                                                                                                  |
-| onSuccess         | function |     yes     |                                                                                                                                                                                                  |
-| onError           | function |     no      |                                                                                                                                                                                                  |
-| state             | string   |     no      |                                                                   randomly generated string (recommend to keep default value)                                                                    |
-| scope             | string   |     no      |                                                                                         'r_emailaddress'                                                                                         |
-|                   |          |             | See LinkedIn's [OAuth permission documentation](https://learn.microsoft.com/en-us/linkedin/shared/authentication/authentication#member-auth-permissions). Separate multiple scopes with a space. |
-| popupWidth        | number   |     no      |                                                                                               600                                                                                                |
-| popupHeight       | number   |     no      |                                                                                               600                                                                                                |
-| closePopupMessage | string   |     no      |                                                                                     'User closed the popup'                                                                                      |
-| children          | function |     no      |                                                                   Required when using the `LinkedIn` component (render props)                                                                    |
+| Parameter         | value    | is required |                                                                                                                                                       default                                                                                                                                                       |
+| ----------------- | -------- | :---------: | :-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------: |
+| clientId          | string   |     yes     |                                                                                                                                                                                                                                                                                                                     |
+| redirectUri       | string   |     yes     |                                                                                                                                                                                                                                                                                                                     |
+| onSuccess         | function |     yes     |                                                                                                                                                                                                                                                                                                                     |
+| onError           | function |     no      |                                                                                                                                                                                                                                                                                                                     |
+| state             | string   |     no      |                                                                                                                             randomly generated string (recommend to keep default value)                                                                                                                             |
+| scope             | string   |     no      |                                                                                                                                               'openid profile email'                                                                                                                                                |
+|                   |          |             | Include `openid` for OIDC. The library warns without blocking if it is omitted. Scope separators using spaces, `%20`, commas, or `+` are normalized to spaces. See LinkedIn's [OpenID Connect documentation](https://learn.microsoft.com/en-us/linkedin/consumer/integrations/self-serve/sign-in-with-linkedin-v2). |
+| popupWidth        | number   |     no      |                                                                                                                                                         600                                                                                                                                                         |
+| popupHeight       | number   |     no      |                                                                                                                                                         600                                                                                                                                                         |
+| closePopupMessage | string   |     no      |                                                                                                                                               'User closed the popup'                                                                                                                                               |
+| children          | function |     no      |                                                                                                                             Required when using the `LinkedIn` component (render props)                                                                                                                             |
 
 Reference: [LinkedIn Authorization Code Flow](https://learn.microsoft.com/en-us/linkedin/shared/authentication/authorization-code-flow#step-2-request-an-authorization-code)
 
@@ -265,7 +285,9 @@ Follow the version-specific commands in [Installation](#installation).
 
 ## Migration guide
 
-Upgrading an existing integration from version 1? See the [version 1 to version 2 migration guide](./MIGRATION-from-1-to-2.md).
+- Upgrading from version 2? See the [version 2 to version 3 migration guide](./MIGRATION-from-2-to-3.md).
+- Upgrading from version 1? Start with the [version 1 to version 2 migration guide](./MIGRATION-from-1-to-2.md), then continue with the version 3 guide.
+- Existing applications that still depend on LinkedIn's deprecated `r_liteprofile` or `r_emailaddress` scopes must remain on `react-linkedin-login-oauth2@^2` until they migrate their LinkedIn application to OpenID Connect.
 
 ## Contributors ✨
 

--- a/README.md
+++ b/README.md
@@ -31,7 +31,6 @@ This library completes the browser portion of LinkedIn's OpenID Connect authoriz
   - [Exchange the authorization code](#exchange-the-authorization-code)
   - [Use the OpenID Connect identity](#use-the-openid-connect-identity)
   - [Security](#security)
-- [Support IE](#support-ie)
   - [Demo](#demo)
   - [Props](#props)
   - [Migration guide](#migration-guide)
@@ -247,13 +246,9 @@ See LinkedIn's [OpenID Connect documentation](https://learn.microsoft.com/en-us/
 
 The LinkedIn Client ID is public and may be passed to this library. The Client Secret must remain on your backend, ideally in a server-side environment variable or secret manager. Only your backend should exchange authorization codes for access tokens. Keep the returned access token secure and, where possible, use it from the backend rather than exposing it to the browser.
 
-# Support IE
-
-- Support for IE is dropped from version `2`
-
 ## Demo
 
-- Source code: https://github.com/nvh95/react-linkedin-login-oauth2-demo/blob/master/src/App.js
+- Source code: https://github.com/nvh95/react-linkedin-login-oauth2/blob/master/preview/LinkedInPageHook.jsx
 - In action: [https://stupefied-goldberg-b44ee5.netlify.app/](https://stupefied-goldberg-b44ee5.netlify.app/)
 
 ## Props

--- a/README.md
+++ b/README.md
@@ -27,15 +27,13 @@ This library completes the browser portion of LinkedIn's OpenID Connect authoriz
   - [Installation](#installation)
   - [Overview](#overview)
   - [Usage](#usage)
+  - [Sign-in button image](#sign-in-button-image)
   - [Exchange the authorization code](#exchange-the-authorization-code)
   - [Use the OpenID Connect identity](#use-the-openid-connect-identity)
   - [Security](#security)
 - [Support IE](#support-ie)
   - [Demo](#demo)
   - [Props](#props)
-  - [Issues](#issues)
-    - [Failed to minify the code from this file: ./node\_modules/react-linkedin-login-oauth2/node\_modules/query-string/index.js:8](#failed-to-minify-the-code-from-this-file-node_modulesreact-linkedin-login-oauth2node_modulesquery-stringindexjs8)
-  - [Known issue](#known-issue)
   - [Migration guide](#migration-guide)
   - [Contributors ✨](#contributors-)
 
@@ -65,7 +63,7 @@ First, we create a button and provide required props:
 
 ```js
 import { useLinkedIn } from 'react-linkedin-login-oauth2';
-// You can use provided image shipped by this package or using your own
+// You can use a provided image shipped by this package or your own button.
 import linkedin from 'react-linkedin-login-oauth2/assets/linkedin.png';
 
 function LinkedInPage() {
@@ -103,7 +101,7 @@ If you do not want to use hooks, the library also provides a render-props compon
 
 ```js
 import { LinkedIn } from 'react-linkedin-login-oauth2';
-// You can use provided image shipped by this package or using your own
+// You can use a provided image shipped by this package or your own button.
 import linkedin from 'react-linkedin-login-oauth2/assets/linkedin.png';
 
 function LinkedInPage() {
@@ -164,6 +162,16 @@ export default function LinkedInCallbackPage() {
   return <LinkedInCallback />;
 }
 ```
+
+## Sign-in button image
+
+The existing sign-in image remains bundled for backward compatibility:
+
+```js
+import linkedin from 'react-linkedin-login-oauth2/assets/linkedin.png';
+```
+
+For current official button images and branding guidance, visit LinkedIn's [Sign in with LinkedIn using OpenID Connect documentation](https://learn.microsoft.com/en-us/linkedin/consumer/integrations/self-serve/sign-in-with-linkedin-v2) and download the assets from its **Image Resources** section. The additional official image variants are not bundled with this package.
 
 ## Exchange the authorization code
 
@@ -270,18 +278,6 @@ Reference: [LinkedIn Authorization Code Flow](https://learn.microsoft.com/en-us/
 
 - `LinkedInCallback` component:  
   No parameters needed
-
-## Issues
-
-Please create an issue at [https://github.com/nvh95/react-linkedin-login-oauth2/issues](https://github.com/nvh95/react-linkedin-login-oauth2/issues). I will spend time to help you.
-
-#### Failed to minify the code from this file: ./node_modules/react-linkedin-login-oauth2/node_modules/query-string/index.js:8
-
-Please upgrade `react-linkedin-login-oauth2` to latest version following
-
-Follow the version-specific commands in [Installation](#installation).
-
-## Known issue
 
 ## Migration guide
 

--- a/package.json
+++ b/package.json
@@ -1,15 +1,16 @@
 {
   "name": "react-linkedin-login-oauth2",
-  "version": "2.1.0-alpha.0",
+  "version": "3.0.0",
   "packageManager": "pnpm@11.5.0",
-  "description": "React component for Linked In Log In feature using OAuth 2.0",
+  "description": "React components for Sign in with LinkedIn using OpenID Connect",
   "main": "build/index.js",
   "module": "build/index.esm.js",
   "types": "./build/index.d.ts",
   "sideEffects": false,
   "files": [
     "build",
-    "assets"
+    "assets",
+    "MIGRATION-*.md"
   ],
   "scripts": {
     "clean": "node -e \"require('node:fs').rmSync('build', { recursive: true, force: true })\"",
@@ -68,6 +69,8 @@
     "signin",
     "oauth",
     "oauth2",
+    "oidc",
+    "openid-connect",
     "redirect"
   ]
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-linkedin-login-oauth2",
-  "version": "3.0.0",
+  "version": "3.0.0-alpha.0",
   "packageManager": "pnpm@11.5.0",
   "description": "React components for Sign in with LinkedIn using OpenID Connect",
   "main": "build/index.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-linkedin-login-oauth2",
-  "version": "3.0.0-alpha.0",
+  "version": "3.0.0",
   "packageManager": "pnpm@11.5.0",
   "description": "React components for Sign in with LinkedIn using OpenID Connect",
   "main": "build/index.js",

--- a/preview/LinkedInPageHook.jsx
+++ b/preview/LinkedInPageHook.jsx
@@ -11,7 +11,7 @@ function LinkedInPage() {
       console.log(code);
       setCode(code);
     },
-    scope: 'openid profile email',
+    scope: 'openid,profile,email',
     onError: (error) => {
       console.log(error);
       setErrorMessage(error.errorMessage);

--- a/src/__tests__/useLinkedIn.test.tsx
+++ b/src/__tests__/useLinkedIn.test.tsx
@@ -134,8 +134,9 @@ describe('useLinkedIn', () => {
       throw new Error('LinkedIn authorization URL was not opened');
     }
     const authorizationUrl = new URL(openedUrl);
-    expect(authorizationUrl.searchParams.get('scope')).toBe('r_emailaddress');
-    expect(console.warn).toHaveBeenCalledTimes(1);
+    expect(authorizationUrl.searchParams.get('scope')).toBe(
+      'openid profile email',
+    );
 
     const state = localStorage.getItem(LINKEDIN_OAUTH2_STATE);
     act(() => {
@@ -156,6 +157,41 @@ describe('useLinkedIn', () => {
     expect(onError).not.toHaveBeenCalled();
     expect(localStorage.getItem(LINKEDIN_OAUTH2_STATE)).toBeNull();
   });
+
+  test('warns without blocking when a custom scope omits openid', () => {
+    const onSuccess = vi.fn();
+    const onError = vi.fn();
+
+    renderAndOpenPopup(onSuccess, onError, {
+      scope: 'r_emailaddress r_liteprofile',
+    });
+
+    expect(window.open).toHaveBeenCalledTimes(1);
+    expect(onSuccess).not.toHaveBeenCalled();
+    expect(onError).not.toHaveBeenCalled();
+    expect(console.warn).toHaveBeenCalledWith(
+      'The scope must include "openid" for Sign in with LinkedIn using OpenID Connect',
+    );
+    expect(localStorage.getItem(LINKEDIN_OAUTH2_STATE)).not.toBeNull();
+  });
+
+  test.each(['openid%20email', 'openid,email', 'openid+email'])(
+    'normalizes the encoded scope %s',
+    (scope) => {
+      const onSuccess = vi.fn();
+      const onError = vi.fn();
+
+      renderAndOpenPopup(onSuccess, onError, { scope });
+
+      const openedUrl = vi.mocked(window.open).mock.calls[0]?.[0];
+      if (!openedUrl) {
+        throw new Error('LinkedIn authorization URL was not opened');
+      }
+
+      expect(new URL(openedUrl).searchParams.get('scope')).toBe('openid email');
+      expect(console.warn).not.toHaveBeenCalled();
+    },
+  );
 
   test('reports a blocked popup', () => {
     const onSuccess = vi.fn();

--- a/src/useLinkedIn.tsx
+++ b/src/useLinkedIn.tsx
@@ -6,8 +6,7 @@ import {
   LINKEDIN_OAUTH2_STATE,
 } from './utils';
 
-const LEGACY_SCOPES = ['r_emailaddress', 'r_liteprofile'];
-let hasWarnedAboutLegacyScope = false;
+const DEFAULT_SCOPE = 'openid profile email';
 
 const getPopupPositionProperties = ({ width = 600, height = 600 }) => {
   const left = screen.width / 2 - width / 2;
@@ -15,26 +14,20 @@ const getPopupPositionProperties = ({ width = 600, height = 600 }) => {
   return `left=${left},top=${top},width=${width},height=${height}`;
 };
 
-const warnAboutLegacyScope = (scope: string) => {
-  const scopes = scope.split(/\s+/);
-  const usesLegacyScope = LEGACY_SCOPES.some((legacyScope) =>
-    scopes.includes(legacyScope),
-  );
-
-  if (usesLegacyScope && !hasWarnedAboutLegacyScope) {
-    console.warn(
-      '[react-linkedin-login-oauth2] LinkedIn deprecated the legacy Sign In with LinkedIn flow on August 1, 2023. Legacy scopes remain supported by this 2.x release for existing applications. Plan to migrate to Sign In with LinkedIn using OpenID Connect.',
-    );
-    hasWarnedAboutLegacyScope = true;
-  }
-};
+const normalizeScope = (scope: string) =>
+  scope
+    .replace(/%20|[,+]/gi, ' ')
+    .trim()
+    .split(/\s+/)
+    .filter(Boolean)
+    .join(' ');
 
 export function useLinkedIn({
   redirectUri,
   clientId,
   onSuccess,
   onError,
-  scope = 'r_emailaddress',
+  scope = DEFAULT_SCOPE,
   state = '',
   closePopupMessage = 'User closed the popup',
   popupWidth = 600,
@@ -115,13 +108,20 @@ export function useLinkedIn({
   }, [receiveMessage]);
 
   const getUrl = () => {
-    warnAboutLegacyScope(scope);
+    const normalizedScope = normalizeScope(scope);
+
+    if (!normalizedScope.split(' ').includes('openid')) {
+      console.warn(
+        'The scope must include "openid" for Sign in with LinkedIn using OpenID Connect',
+      );
+    }
+
     const generatedState = state || generateRandomState();
     localStorage.setItem(LINKEDIN_OAUTH2_STATE, generatedState);
     return buildLinkedInAuthorizationUrl({
       clientId,
       redirectUri,
-      scope,
+      scope: normalizedScope,
       state: generatedState,
     });
   };


### PR DESCRIPTION
## Summary

- update the default LinkedIn scope to `openid profile email`
- normalize custom space-, `%20`-, comma-, and `+`-delimited scope values
- warn when a custom scope omits `openid` without blocking authorization
- add the v2-to-v3 migration guide and OpenID Connect backend guidance
- update package metadata, changelog, preview, and README for version 3.0.0

## Testing

- `pnpm test` — 12 tests passed
- `pnpm typecheck`
- `pnpm lint`
- `pnpm build`